### PR TITLE
Fix NullPointerException when listing rejected user datasets

### DIFF
--- a/src/main/java/org/veupathdb/service/userds/service/JobService.java
+++ b/src/main/java/org/veupathdb/service/userds/service/JobService.java
@@ -140,6 +140,8 @@ public class JobService
     // return.
     } else if (row.getStatus() == JobStatus.REJECTED && row.getMessage().isPresent()) {
       var dets = new ValidationErrorsImpl();
+      dets.setErrors(new ValidationErrorsImpl.ErrorsTypeImpl());
+      dets.getErrors().setGeneral(new ArrayList<>());
       var raw  = row.getMessage().get();
 
       if (raw.has("general")) {

--- a/src/main/java/org/veupathdb/service/userds/service/JobService.java
+++ b/src/main/java/org/veupathdb/service/userds/service/JobService.java
@@ -140,11 +140,11 @@ public class JobService
     // return.
     } else if (row.getStatus() == JobStatus.REJECTED && row.getMessage().isPresent()) {
       var dets = new ValidationErrorsImpl();
-      dets.setErrors(new ValidationErrorsImpl.ErrorsTypeImpl());
-      dets.getErrors().setGeneral(new ArrayList<>());
       var raw  = row.getMessage().get();
 
       if (raw.has("general")) {
+        dets.setErrors(new ValidationErrorsImpl.ErrorsTypeImpl());
+        dets.getErrors().setGeneral(new ArrayList<>());
         raw.get("general")
           .forEach(j -> dets.getErrors().getGeneral().add(j.textValue()));
       }

--- a/src/main/java/org/veupathdb/service/userds/service/JobService.java
+++ b/src/main/java/org/veupathdb/service/userds/service/JobService.java
@@ -141,15 +141,16 @@ public class JobService
     } else if (row.getStatus() == JobStatus.REJECTED && row.getMessage().isPresent()) {
       var dets = new ValidationErrorsImpl();
       var raw  = row.getMessage().get();
+      dets.setErrors(new ValidationErrorsImpl.ErrorsTypeImpl());
 
       if (raw.has("general")) {
-        dets.setErrors(new ValidationErrorsImpl.ErrorsTypeImpl());
         dets.getErrors().setGeneral(new ArrayList<>());
         raw.get("general")
           .forEach(j -> dets.getErrors().getGeneral().add(j.textValue()));
       }
 
       if (raw.has("byKey")) {
+        dets.getErrors().setByKey(new ValidationErrorsImpl.ErrorsTypeImpl.ByKeyTypeImpl());
         var obj = raw.get("byKey");
         obj.fieldNames()
           .forEachRemaining(k -> dets.getErrors()


### PR DESCRIPTION
Fixing issue that Jay is running into with UserDatasets.

I'm not exactly why this hasn't been hit before in biom datasets. I'll do some digging into that handler to try to understand why.

```
java.lang.NullPointerException: Cannot invoke "org.veupathdb.service.userds.generated.model.ValidationErrors$ErrorsType.getGeneral()" because the return value of "org.veupathdb.service.userds.generated.model.ValidationErrorsImpl.getErrors()" is null
        at org.veupathdb.service.userds.service.JobService.lambda$rowToStatus$1(JobService.java:147) ~[service.jar:1.0.0]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at org.veupathdb.service.userds.service.JobService.rowToStatus(JobService.java:147) ~[service.jar:1.0.0]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at org.veupathdb.service.userds.controller.UserDatasetController.getUserDatasets(UserDatasetController.java:91) ~[service.jar:1.0.0]
        at jdk.internal.reflect.GeneratedMethodAccessor5.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[service.jar:1.0.0]
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:475) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:397) [service.jar:1.0.0]
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81) [service.jar:1.0.0]
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:255) [service.jar:1.0.0]
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) [service.jar:1.0.0]
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) [service.jar:1.0.0]
        at org.glassfish.jersey.internal.Errors.process(Errors.java:292) [service.jar:1.0.0]
        at org.glassfish.jersey.internal.Errors.process(Errors.java:274) [service.jar:1.0.0]
        at org.glassfish.jersey.internal.Errors.process(Errors.java:244) [service.jar:1.0.0]
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265) [service.jar:1.0.0]
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234) [service.jar:1.0.0]
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684) [service.jar:1.0.0]
        at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:356) [service.jar:1.0.0]
        at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:190) [service.jar:1.0.0]
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535) [service.jar:1.0.0]
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515) [service.jar:1.0.0]
        at java.lang.Thread.run(Thread.java:831) [?:?]
```