### PR TITLE
Add a metric for upload by dataset type

### DIFF
--- a/src/main/java/org/veupathdb/service/userds/controller/UserDatasetController.java
+++ b/src/main/java/org/veupathdb/service/userds/controller/UserDatasetController.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
@@ -28,6 +29,7 @@ import org.veupathdb.service.userds.repo.SelectJobsQuery;
 import org.veupathdb.service.userds.service.Importer;
 import org.veupathdb.service.userds.service.JobService;
 import org.veupathdb.service.userds.service.ThreadProvider;
+import org.veupathdb.service.userds.service.metrics.ImportMetrics;
 import org.veupathdb.service.userds.util.InputStreamNotifier;
 
 import static org.veupathdb.service.userds.service.JobService.deleteJobById;
@@ -179,6 +181,7 @@ public class UserDatasetController implements UserDatasets
         lock.wait();
       }
 
+      ImportMetrics.emitSuccessfulUploadByType(1, job.getType());
       return PostUserDatasetsByJobIdResponse.respond200WithApplicationJson(new ProcessResponseImpl());
     } catch (WebApplicationException e) {
       // Don't catch Jax-RS exceptions.

--- a/src/main/java/org/veupathdb/service/userds/service/metrics/ImportMetrics.java
+++ b/src/main/java/org/veupathdb/service/userds/service/metrics/ImportMetrics.java
@@ -1,0 +1,16 @@
+package org.veupathdb.service.userds.service.metrics;
+
+import io.prometheus.client.Counter;
+
+public class ImportMetrics {
+
+  private static final Counter COUNT_BY_TYPE = Counter.build()
+      .name("dataset_upload")
+      .help("Total successfully uploaded datasets.")
+      .labelNames("type")
+      .register();
+
+  public static void emitSuccessfulUploadByType(int count, String type) {
+    COUNT_BY_TYPE.labels(type).inc(count);
+  }
+}


### PR DESCRIPTION
## Overview
Simple change to emit a metric by dataset type.

Resolves #37

## Testing
Tested locally by invoking `/metrics` endpoint
`dataset_upload_created{type="gene-list",} 1.659962852718E9`