### PR TITLE
Replace tar.gz with gz to comply with client compatibility

### DIFF
--- a/src/main/java/org/veupathdb/service/userds/controller/ProjectController.java
+++ b/src/main/java/org/veupathdb/service/userds/controller/ProjectController.java
@@ -13,7 +13,7 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 
 public class ProjectController implements Projects {
-  private static final String[] BASE_FILE_TYPES = {"zip", "tar.gz", "tgz"};
+  private static final String[] BASE_FILE_TYPES = {"zip", "gz", "tgz"};
 
   @Override
   public GetProjectsResponse getProjects() {


### PR DESCRIPTION
## Overview
Replacing `.tar.gz` allowed extension with `.gz` since the upload form in the client seems to crash with `.tar.gz`. I didn't see any other usages outside of letting the client know the allowed extensions.

## Testing
* Deployed locally
* Verified response from `https://udis-dev.local.apidb.org:8443/projects/ClinEpiDB/datasetTypes/isasimple/fileTypes`